### PR TITLE
Add about page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,9 @@ minimal_mistakes_skin    : "cam-blue" # "air", "aqua", "contrast", "dark", "dirt
 
 # Site Settings
 locale                   : "en-GB"
-title                    : "Cambridge University Powerlifting Club"
+title                    : "Cambridge University "
 title_separator          : "-"
-subtitle                 : # site tagline that appears below site title in masthead
+subtitle                 : "Powerlifting Club"
 name                     : "Bilal Chughtai"
 description              : "The strongest society in Cambridge"
 url                      : https://cuplc.co.uk # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,5 @@ main:
     url: /resources/
   - title: "Blog"
     url: /blog/
+  - title: "About"
+    url: /about/

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,0 +1,11 @@
+---
+title: Blog
+layout: splash
+permalink: /blog/
+header:
+  overlay_color: "#000"
+  overlay_filter: "0.5"
+  overlay_image: /assets/images/varsity_2020_group.jpg
+  caption: "Varsity 2020"
+
+---

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,7 @@
 ---
-title: Blog
+title: About
 layout: splash
-permalink: /blog/
+permalink: /about/
 header:
   overlay_color: "#000"
   overlay_filter: "0.5"

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -55,7 +55,7 @@
 
 .site-subtitle {
   display: block;
-  font-size: $type-size-8;
+  //font-size: $type-size-8;
 }
 
 .masthead__menu {


### PR DESCRIPTION
There's not enough room for another menu item, so it's squashed it into one of those hamburger menu buttons

Some options:

* make the text of the menu items smaller
* make the "cambridge university powerlifting club" image smaller
* Remove one of the existing menu items

The too-wide image is generated from the config title item

`title  : "Cambridge University Powerlifting Club"`